### PR TITLE
JSON objects support, static values, emptying columns

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ In the example below, the database dump file is in the `/path/to/databse/dump/` 
 }
 ```
 
-#### Working with local database dump
+#### Working with remote database dump
 In the example below, the database dump file is stored on a remote server with an IP address of `1.2.3.4` and ssh port of `5022`. The ssh user's name is `anonymizer`, the directory on remote host with the database dump is `/path/to/databse/dump/`.  In this case, let's assume that we need to add `--rsync-path=\"sudo rsync\"` option to our rsync dump download command.
 
 ```
@@ -169,6 +169,37 @@ Anonymizer can also work with Magento's EAV model. In the example below, the cus
 }
 ```
 
+#### How to work with JSON data
+Anonymizer can now update values of JSON encoded data. In below example we anonymize json stored in `additional_data` column.
+You should familiarize with MySQL JSON path expressions.
+```
+{ "id": 123, "user": { "first_name": "John", "last_name": "Smith", "phone": "123-456-789" }, (...) }
+```
+
+```
+"tables":{
+    "subscriptions":{
+        "additional_data":{
+            "action":"json_update",
+            "fields":[
+                {
+                    "path":"$.user.first_name",
+                    "type":"firstname"
+                },
+                {
+                    "path":"$.user.last_name",
+                    "type":"lastname"
+                },
+                {
+                    "path":"$.user.phone",
+                    "type":"telephone"
+                }
+            ]
+        }
+    }
+}
+```
+
 ### Example configuration file 
 ```
 {
@@ -206,6 +237,29 @@ Anonymizer can also work with Magento's EAV model. In the example below, the cus
                         "entity_type": "customer"
                     }
                 ]
+            }
+        },
+        "subscriptions":{
+            "additional_data":{
+                "action":"json_update",
+                "fields":[
+                    {
+                        "path":"$.user.first_name",
+                        "type":"firstname"
+                    },
+                    {
+                        "path":"$.user.last_name",
+                        "type":"lastname"
+                    },
+                    {
+                        "path":"$.user.phone",
+                        "type":"telephone"
+                    }
+                ]
+            },
+            "comment": {
+                "type": "quote",
+                "action": "update"
             }
         }
     }

--- a/README.md
+++ b/README.md
@@ -150,6 +150,31 @@ In the example below, the data in the `log_customer` table will be truncated.
 }
 ```
 
+#### How to empty only selected columns in a table?
+In the example below we will empty data in column with configuration values, keeping other columns intact.
+```
+"tables": {
+    "some_configuration_table": {
+        "config_value": {
+            "action": "empty"
+        }
+    }
+}
+```
+
+#### How to set static value to a column?
+In below example value `PLN` will be assigned to column `base_currency` for all users.
+```
+"tables": {
+    "users": {
+        "base_currency": {
+            "action": "set_static",
+            "value": "PLN"
+        }
+    }
+}
+```
+
 #### How to use Anonymizer with Magento EAV?
 Anonymizer can also work with Magento's EAV model. In the example below, the customer attribute `about_me` in the  `customer_entity_text` table will be replaced with a random phrase.
 ```

--- a/lib/anonymizer/model/database.rb
+++ b/lib/anonymizer/model/database.rb
@@ -37,6 +37,10 @@ class Database
         info['attributes'].each do |attribute|
           querys.push anonymize_eav_query(table_name, column_name, attribute)
         end
+      elsif info['action'] == 'json_update'
+        info['fields'].each do |field|
+          querys.push anonymize_json_query(table_name, column_name, field)
+        end
       else
         querys.push anonymize_column_query(table_name, column_name, info['type'])
       end
@@ -75,6 +79,16 @@ class Database
                 'entity_type_id ' \
                   'FROM eav_entity_type ' \
                   "WHERE entity_type_code = '#{attribute['entity_type']}'))"
+
+    query
+  end
+
+  def anonymize_json_query(table_name, column_name, field)
+    query = "UPDATE #{table_name} " \
+     'SET ' \
+      "#{column_name} = JSON_REPLACE( #{column_name}, " \
+        "\"#{field['path']}\"" \
+        ", (SELECT fake_user.#{field['type']} FROM fake_user ORDER BY RAND() LIMIT 1) )"
 
     query
   end

--- a/lib/anonymizer/model/database.rb
+++ b/lib/anonymizer/model/database.rb
@@ -87,8 +87,16 @@ class Database
     query = "UPDATE #{table_name} " \
      'SET ' \
       "#{column_name} = JSON_REPLACE( #{column_name}, " \
-        "\"#{field['path']}\"" \
-        ", (SELECT fake_user.#{field['type']} FROM fake_user ORDER BY RAND() LIMIT 1) )"
+        "\"#{field['path']}\", ("
+
+    if field['type'] == 'id'
+      query << 'SELECT FLOOR((NOW() + RAND()) * (RAND() * 119))) '
+    else
+      query << prepare_select_for_query(field['type'])
+      query << 'FROM fake_user ORDER BY RAND() LIMIT 1) '
+    end
+
+    query << ")"
 
     query
   end

--- a/lib/anonymizer/model/database.rb
+++ b/lib/anonymizer/model/database.rb
@@ -33,6 +33,11 @@ class Database
       if info['action'] == 'truncate'
         querys = truncate_column_query(table_name)
         break
+      elsif info['action'] == 'empty'
+        # querys.push empty_column_query(table_name, column_name)
+        querys.push set_static_value_query(table_name, column_name, '')
+      elsif info['action'] == 'set_static'
+        querys.push set_static_value_query(table_name, column_name, info['value'])
       elsif info['action'] == 'eav_update'
         info['attributes'].each do |attribute|
           querys.push anonymize_eav_query(table_name, column_name, attribute)
@@ -109,6 +114,12 @@ class Database
     querys.push 'SET FOREIGN_KEY_CHECKS = 1;'
 
     querys
+  end
+
+  def set_static_value_query(table_name, column_name, value)
+    query = "UPDATE #{table_name} SET #{column_name} = '#{value}'"
+
+    query
   end
 
   def insert_fake_data


### PR DESCRIPTION
Because we needed finer control, I have added support for changing json objects elements' values, setting static values in select columns and emptying chosen columns as an option besides truncating whole tables.
Usage is described in updated readme file.