### PR TITLE
Customizable where clause - pim5 roles are not anonymized thanks to this

### DIFF
--- a/lib/anonymizer/model/database/column.rb
+++ b/lib/anonymizer/model/database/column.rb
@@ -13,6 +13,18 @@ class Database
       query += manage_type(column_type)
       query += "WHERE #{table_name}.#{column_name} IS NOT NULL"
 
+      if (info.key?('where'))
+        info['where'].each do |where_info|
+          if where_info == info['where'].first
+            query << " AND"
+          elsif
+            query << " #{where_info['logical_operator']}"
+          end
+          
+          query << " #{table_name}.#{where_info['column']} #{where_info['operator']} '#{where_info['value']}'"
+        end
+      end
+
       querys.push query
 
       querys

--- a/lib/anonymizer/model/database/column.rb
+++ b/lib/anonymizer/model/database/column.rb
@@ -36,13 +36,22 @@ class Database
       query = ''
 
       if info.key?('where')
+        raise ArgumentError, 'Where MUST be an array with proper fields' unless info['where'].is_a?(Array)
         info['where'].each do |where_info|
+          check_where_clause(where_info)
           query += " #{where_info['logical_operator']} "
           query += "#{table_name}.#{where_info['column']} #{where_info['operator']} '#{where_info['value']}'"
         end
       end
 
       query
+    end
+
+    def self.check_where_clause(where_clause)
+      require_fields = %w[logical_operator column operator value]
+      require_fields.each do |required_field|
+        raise ArgumentError, "#{required_field} is required in WHERE clause" unless where_clause.key?(required_field)
+      end
     end
   end
 end

--- a/lib/anonymizer/model/database/column.rb
+++ b/lib/anonymizer/model/database/column.rb
@@ -12,18 +12,7 @@ class Database
       query = "UPDATE #{table_name} SET #{column_name} = ("
       query += manage_type(column_type)
       query += "WHERE #{table_name}.#{column_name} IS NOT NULL"
-
-      if (info.key?('where'))
-        info['where'].each do |where_info|
-          if where_info == info['where'].first
-            query << " AND"
-          elsif
-            query << " #{where_info['logical_operator']}"
-          end
-          
-          query << " #{table_name}.#{where_info['column']} #{where_info['operator']} '#{where_info['value']}'"
-        end
-      end
+      query += fill_where_clause(info, table_name)
 
       querys.push query
 
@@ -38,6 +27,19 @@ class Database
       else
         query += prepare_select_for_query(type)
         query += 'FROM fake_user ORDER BY RAND() LIMIT 1) '
+      end
+
+      query
+    end
+
+    def self.fill_where_clause(info, table_name)
+      query = ''
+
+      if info.key?('where')
+        info['where'].each do |where_info|
+          query += " #{where_info['logical_operator']} "
+          query += "#{table_name}.#{where_info['column']} #{where_info['operator']} '#{where_info['value']}'"
+        end
       end
 
       query

--- a/lib/anonymizer/project/basic/pimcore_5.json
+++ b/lib/anonymizer/project/basic/pimcore_5.json
@@ -7,6 +7,7 @@
                 "action": "update",
                 "where": [
                     {
+                        "logical_operator": "AND",
                         "column": "name",
                         "operator": "!=",
                         "value": "system"    

--- a/lib/anonymizer/project/basic/pimcore_5.json
+++ b/lib/anonymizer/project/basic/pimcore_5.json
@@ -2,13 +2,22 @@
     "type": "basic",
     "tables": {
         "users": {
-            "email": {
-                "type": "email",
-                "action": "update"
-            },
             "name": {
                 "type": "login",
-                "action": "update"
+                "action": "update",
+                "where": [
+                    {
+                        "column": "name",
+                        "operator": "!=",
+                        "value": "system"    
+                    },
+                    {
+                        "logical_operator": "AND",
+                        "column": "type",
+                        "operator": "=",
+                        "value": "user"    
+                    }
+                ]
             },
             "firstname": {
                 "type": "firstname",
@@ -16,6 +25,10 @@
             },
             "lastname": {
                 "type": "lastname",
+                "action": "update"
+            },
+            "email": {
+                "type": "email",
                 "action": "update"
             }
         }

--- a/spec/unit/model/database/column_spec.rb
+++ b/spec/unit/model/database/column_spec.rb
@@ -10,6 +10,81 @@ RSpec.describe Database::Column, '#eav' do
     expect(Object.const_defined?('Database::Column')).to be true
   end
 
+  context '#Proper additional where clause (single)' do
+    info = {}
+    info['where'] = JSON.parse('
+        [
+            {
+                "logical_operator": "AND",
+                "column": "name",
+                "operator": "!=",
+                "value": "system"
+            }
+        ]
+    ')
+
+    it 'should add where clause' do
+      expect(Database::Column.fill_where_clause(info, 'users')).to eq(' AND users.name != \'system\'')
+    end
+  end
+
+  context '#Proper additional where clause (multiple)' do
+    info = {}
+    info['where'] = JSON.parse('
+        [
+            {
+                "logical_operator": "AND",
+                "column": "name",
+                "operator": "!=",
+                "value": "system"
+            },
+            {
+                "logical_operator": "AND",
+                "column": "type",
+                "operator": "=",
+                "value": "user"
+            }
+        ]
+    ')
+
+    it 'should add where clause' do
+      expect(Database::Column.fill_where_clause(info, 'users')).to eq(
+                                                                       ' AND users.name != \'system\' AND users.type = \'user\''
+                                                                   )
+    end
+  end
+
+  context '#No where clause' do
+    info = {}
+    it 'should not add where clause' do
+      expect(Database::Column.fill_where_clause(info, 'users')).to eq('')
+    end
+  end
+
+  context '#Empty where clause' do
+    info = {}
+    info['where'] = ''
+    it 'should raise error on empty where clause' do
+      expect { Database::Column.fill_where_clause(info, 'users') }.to raise_error(ArgumentError)
+    end
+  end
+
+  context '#Incorrect where clause' do
+    info = {}
+    info['where'] = JSON.parse('
+        [
+            {
+                "column": "name",
+                "operator": "!=",
+                "value": "system"
+            }
+        ]
+    ')
+    it 'should raise error on incorrect where clause' do
+      expect { Database::Column.fill_where_clause(info, 'users') }.to raise_error(ArgumentError)
+    end
+  end
+
   context 'work with email type' do
     info = {}
     table_name = 'sales_flat_order_address'

--- a/spec/unit/model/database/column_spec.rb
+++ b/spec/unit/model/database/column_spec.rb
@@ -49,8 +49,8 @@ RSpec.describe Database::Column, '#eav' do
 
     it 'should add where clause' do
       expect(Database::Column.fill_where_clause(info, 'users')).to eq(
-                                                                       ' AND users.name != \'system\' AND users.type = \'user\''
-                                                                   )
+        ' AND users.name != \'system\' AND users.type = \'user\''
+      )
     end
   end
 


### PR DESCRIPTION
Right now during anonymization of Pimcore5 databases not only users were anonymized but also roles and folders - it is because all of it is in the one table (users). 

Here you can see that folders are also anonymized (not only users)
![image](https://user-images.githubusercontent.com/16497506/49340072-23dd2900-f63b-11e8-9879-256f8a5c5c92.png)

Here you can see that roles are anonymized (and folders inside also):
![image](https://user-images.githubusercontent.com/16497506/49340086-5ab33f00-f63b-11e8-8161-a4b7ec603e9c.png)

I think that this is not necessary. Moreover - IMHO it is not recommended (because we lose some system data). 

This PR introduces customizable where clause - thanks to this we can anonymize just users without folders and roles. It is fully customizable so can be used also in other purposes (and is backward compatible of course).

:information_source: First logical condition is always AND (that's why it isn't in the configuration)