### PR TITLE
Multiple tables can be update at once with the same data Pimcore related

### DIFF
--- a/lib/anonymizer/model/database.rb
+++ b/lib/anonymizer/model/database.rb
@@ -69,6 +69,8 @@ class Database
       class_name = 'Eav'
     when 'json_update'
       class_name = 'Json'
+    when 'multiple_update'
+      class_name = 'Multiple'
     else
       class_name = 'Column'
     end

--- a/lib/anonymizer/model/database/multiple.rb
+++ b/lib/anonymizer/model/database/multiple.rb
@@ -1,0 +1,45 @@
+# Basic class to communication with databese
+class Database
+  # Class to anonymize multiple tables at onces with the same data
+  class Multiple < Database
+    def self.query(table_name, column_name, info)
+      column_type = info['type']
+
+      querys = []
+
+      query = "UPDATE #{table_name} SET #{column_name} = ("
+      query += manage_type(column_type)
+      query += "WHERE #{table_name}.#{column_name} IS NOT NULL"
+
+      querys.push query
+      querys = manage_linked_tables(info['linked_tables'], table_name, column_name, querys)
+
+      querys
+    end
+
+    def self.manage_type(type)
+      query = ''
+
+      if type == 'id'
+        query += 'SELECT FLOOR((NOW() + RAND()) * (RAND() * 119))) '
+      else
+        query += prepare_select_for_query(type)
+        query += 'FROM fake_user ORDER BY RAND() LIMIT 1) '
+      end
+
+      query
+    end
+
+    def self.manage_linked_tables(linked_tables, table_name, column_name, querys)
+      linked_tables.each do |linked_table, linked_data|
+        query = "UPDATE #{linked_table} as t1"
+        query += " INNER JOIN #{table_name} as t2 ON t1.#{linked_data['column']}"
+        query += " SET t1.#{column_name} = t2.#{column_name}"
+        query += " WHERE t1.#{column_name} IS NOT NULL"
+        querys.push query
+      end
+
+      querys
+    end
+  end
+end


### PR DESCRIPTION
In Pimcore we have got default tables but also dynamic object tables: https://pimcore.com/docs/5.x/Development_Documentation/Development_Tools_and_Details/Database_Model.html#page_Object-Tables

Because of that we MUST (IMHO) anonymize few tables with the same data - Multiple class is for this! :smile: 

Thanks to this we can have:
```
"tables": {
    "object_store_12": {
            "comment": {
                "type": "quote",
                "action": "multiple_update",
                "linked_tables": {
                    "object_query_12": {
                        "column": "oo_id"
                    }
                }
            }
    }
}
```

Which will anonymize `comment` column from `object_store_12` AND `comment` column from `object_query_12` (`oo_id` is a column to compare fields)

It can be useful e.g. when Pimcore5 e-commerce plugin is on (but also in other cases).

Change is of course backward compatible so it is just an addition and won't break anything.