### PR TITLE
scenerio feature

### DIFF
--- a/lib/anonymizer/helper/shell_helper.rb
+++ b/lib/anonymizer/helper/shell_helper.rb
@@ -34,6 +34,15 @@ module ShellHelper
     remove_white_space(command)
   end
 
+  def self.output_query_result(project_name, table, where, database, outputfile)
+    if !where.nil?
+        command = "mysqldump #{mysql_options(database)} #{project_name} #{table} --where='#{where}' --skip-opt --no-create-info --compact  >> #{outputfile}"
+    else
+        command = "mysqldump #{mysql_options(database)} #{project_name} #{table} --skip-opt --no-create-info --compact  >> #{outputfile}"
+    end
+    remove_white_space(command)
+  end
+
   def self.upload_to_web(project_name, database, web_server, tmp_dir, options = '')
     random_string = "_#{database[:random_string]}" if database[:random_string]
     command = "rsync -a #{ssh_option(web_server[:port])} #{options} " \

--- a/lib/anonymizer/model/anonymizer.rb
+++ b/lib/anonymizer/model/anonymizer.rb
@@ -4,7 +4,7 @@
 class Anonymizer
   attr_accessor :config
 
-  def initialize(project_name, config = nil)
+  def initialize(project_name, config = nil, scenerio = 'default')
     raise 'Invalid project name' unless project_name && project_name.is_a?(String)
     @project_name = project_name
 
@@ -14,6 +14,7 @@ class Anonymizer
       config = read_config project_file_path
     end
 
+    config['scenerio'] = scenerio
     @config = prepare_config config
   end
 
@@ -47,7 +48,9 @@ class Anonymizer
 
     config['tables'].each do |_table_name, columns|
       columns.each do |column_name, info|
-        validate_column(column_name, info)
+        info.each do |scenerio, scenerio_body|
+            validate_column(column_name, scenerio, scenerio_body)
+        end
       end
     end
   end
@@ -58,8 +61,8 @@ class Anonymizer
     end
   end
 
-  def validate_column(_column_name, info)
-    raise 'In project config file founded column without defined action' unless info['action']
+  def validate_column(_column_name, scenerio, scenerio_body)
+    raise 'In project config file founded column without defined action' unless scenerio_body['action']
   end
 
   def read_config(project_file_path)

--- a/lib/anonymizer/model/database/delete.rb
+++ b/lib/anonymizer/model/database/delete.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+# Basic class to communication with databese
+class Database
+  # Class to remove records
+  class Delete
+    def self.query(table_name, _column_name, info)
+      where = info['attributes']['where']
+      queries = []
+      query = "DELETE FROM #{table_name} WHERE #{where};"
+      queries.push query
+      queries
+    end
+  end
+end


### PR DESCRIPTION
zmiana zapisu projektu z:
`"tables": {
    "test": {
      "testcol": {
          "action": "empty"
      }
    }
  },`

na

`"tables": {
    "test": {
      "testcol": {
        "default": {
          "action": "empty"
        },
        "scenerio": {
          "action": "delete",
          "attributes": {
            "where": "id>0"
          }
        }
      }
    }
  },`

Daje to możliwość tworzenia scenariuszy dzięki którym można czyścić bazę przed wykonaniem anonimizacji w zakresie jaki potrzebujemy (np. zostawiamy jednego bądź kilku klientów)

Dodanie konfiguracji dumpu dla scenariusza:

`"dump_action": {
    "path": "path to dump dir",
    "scenerio": {
      "file": "test.sql",
      "tables": {
        "test": {
          "where": "id in (1,2)"
        },
        "test2": {
        }
      }
    }
  }`

Z pierwszej tabeli zostaną zrzucone dwa rekordy, druga tabela zostanie zrzucona w całości.

Zadanie, które wykonuje scenariusz wraz ze zrzutem to:
`Rake.application.invoke_task("project:anonymize_database_with_scenerio[#{project_name}, default]")`

Domyślnie każda tabela powinna mieć scenariusz default