### PR TITLE
MGDEVOPS-408/allow-sed-replace-before-db-import

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -43,7 +43,8 @@ namespace 'project' do
       ShellHelper.restore_database(
         project_name,
         database,
-        CONFIG['tmp_path']
+        CONFIG['tmp_path'],
+        anonymizer.config['apply_before_db_import']
       )
     )
   end

--- a/lib/anonymizer/helper/shell_helper.rb
+++ b/lib/anonymizer/helper/shell_helper.rb
@@ -16,11 +16,19 @@ module ShellHelper
     remove_white_space(command)
   end
 
-  def self.restore_database(project_name, database, dir)
-    command = "gunzip -c #{dir}/#{project_name}.sql.gz | " \
-      "sed -e 's/DEFINER=[^*]*\\*/\\*/' | " \
-      "sed -e 's/ROW_FORMAT=FIXED//g' | " \
-      "mysql#{mysql_options(database)} #{project_name}"
+  def self.restore_database(project_name, database, dir, options = '')
+    if options == ''
+        command = "gunzip -c #{dir}/#{project_name}.sql.gz | " \
+              "sed -e 's/DEFINER=[^*]*\\*/\\*/' | " \
+              "sed -e 's/ROW_FORMAT=FIXED//g' | " \
+              "mysql#{mysql_options(database)} #{project_name}"
+    else
+        command = "gunzip -c #{dir}/#{project_name}.sql.gz | " \
+              "sed -e 's/DEFINER=[^*]*\\*/\\*/' | " \
+              "sed -e 's/ROW_FORMAT=FIXED//g' | " \
+              "#{options} | " \
+              "mysql#{mysql_options(database)} #{project_name}"
+    end
 
     remove_white_space(command)
   end


### PR DESCRIPTION
This workaround allows to apply additional commands to the unpacked database file just before importing, it's sometimes needed when there is db engines incompatibility (fe. new collates on tables etc.)